### PR TITLE
Remove trailing comma to fix HAOS error

### DIFF
--- a/custom_components/schlage/manifest.json
+++ b/custom_components/schlage/manifest.json
@@ -7,5 +7,5 @@
     "codeowners": ["@mcnutter1"],
     "requirements": [],
     "iot_class": "cloud_polling",
-    "version": "1.0",
+    "version": "1.0"
 }


### PR DESCRIPTION
Home Assistant OS logs an error parsing `manifest.json` when a trailing comma (likely added by `black`?) is present. Removing the comma allowed for correct installation of the Schlage integration on my installation of Home Assistant 2022.12.7.